### PR TITLE
Fix #3

### DIFF
--- a/assets/link_arrow.svg
+++ b/assets/link_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="18" viewBox="0 0 24 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.50769 16L8 14.4923L18.3385 4.15385H9.07692V2H22V14.9231H19.8462V5.66154L9.50769 16Z" fill="black"/>
+</svg>

--- a/assets/link_arrow_white.svg
+++ b/assets/link_arrow_white.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="18" viewBox="0 0 24 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.50769 16L8 14.4923L18.3385 4.15385H9.07692V2H22V14.9231H19.8462V5.66154L9.50769 16Z" fill="white"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,10 @@
       <br />
       <h2>A website for learning about trauma, trauma-informed care, and digital design.</h2>
     </div>
-    <a class="btn" href="https://forms.gle/ZuGq5hq6ZHU74hrFA" target="_blank" aria-label="Suggest a Resource, opens a new window">Suggest a Resource</a>
+    <span>
+      <a class="btn" href="https://forms.gle/ZuGq5hq6ZHU74hrFA" target="_blank" aria-label="Suggest a Resource, opens a new window">Suggest a Resource</a>
+      <span aria-hidden="true"><img src="assets/link_arrow.svg" class="link-icon-large"></span>  
+    </span>
   </header>
 
   <div class="container">
@@ -46,14 +49,25 @@
 
       <div class="copyright">
          <p>Website and collection maintained by the volunteer organizers of the Trauma Informed Design Discussion Group. We do not assess or verify these resources. There may be information here that does not represent the opinions of the volunteers. Some resources such as PDFs may not be accessible, please contact the author to request an accessible document. </p> 
-        <p>Please <a href="https://www.melissaegg.com/contact" target="_blank" aria-label="Contact co-organizer Melissa Eggleston, opens a new window"> contact co-organizer Melissa Eggleston</a> if you have any questions, concerns, or needs.</p>
+        <p>
+          <span>Please </span>
+          <a href="https://www.melissaegg.com/contact" target="_blank" aria-label="Contact co-organizer Melissa Eggleston, opens a new window">contact co-organizer Melissa Eggleston</a>
+          <span aria-hidden="true"><img src="assets/link_arrow.svg" class="link-icon"></span>
+          <span> if you have any questions, concerns, or needs.</span>
+        </p>
 
- <p>
-<a href="https://bit.ly/TIDesignList" target="_blank" aria-label="Request to join group, opens a new window"> Request to join our monthly discussion group here.</a> 
-</p>
+        <p>
+          <a href="https://bit.ly/TIDesignList" target="_blank" aria-label="Request to join group, opens a new window">Request to join our monthly discussion group here.</a> 
+          <span aria-hidden="true"><img src="assets/link_arrow.svg" class="link-icon"></span>
+        </p>
 
 
-        <p>This website was created based on <a href="https://www.ethicaldesignresources.com/" target="_blank" aria-label="Ethical Design Resources, opens a new window">Ethical Design Resources</a> by Lexi Namer. Thank you for the open-source code!</p>
+        <p>
+          <span>This website was created based on </span>
+          <a href="https://www.ethicaldesignresources.com/" target="_blank" aria-label="Ethical Design Resources, opens a new window">Ethical Design Resources</a>
+          <span aria-hidden="true"><img src="assets/link_arrow.svg" class="link-icon"></span>
+          <span> by Lexi Namer. Thank you for the open-source code!</span>
+        </p>
         <p>Copyright &copy; <script>document.write(new Date().getFullYear())</script></p>
       </div>
     </nav>

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -56,11 +56,14 @@ function createCards(year,title,authors,publication,cat,link,desc) {
   var publication = (publication == "") ? "" : '<strong>Publication:</strong> ' + publication;
 
   var card =
-    `<div class="card" tabindex="0" data-category-type="${cat}">
+    `<div class="card" data-category-type="${cat}">
         <a href="${link}" target="_blank">
           <div class="card-header">
             <span class="card-category">${cat}</span>
-            <p class="card-date">${year}</p>
+            <span class="card-date">
+              ${year}
+              <span aria-hidden="true" class="link-icon-card-container"><img src="assets/link_arrow_white.svg" class="link-icon-large"></span>
+            </span>
           </div>
           <div class="card-content">
             <h2 class="card-title">${title}</h2>
@@ -68,6 +71,7 @@ function createCards(year,title,authors,publication,cat,link,desc) {
             <p class="card-publication">${publication}</p>
             <p class="card-desc">${desc}</p>
           </div>
+          <span class="sr-only">Opens a new window</span>
         </a>
       </div>`
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -54,7 +54,6 @@ header h1 {
 }
 
 .btn {
-  border-bottom: 1.5px solid black;
   font-size: 14px;
   font-weight: 500;
   text-transform: uppercase;
@@ -62,6 +61,7 @@ header h1 {
   line-height: 1.4em;
   transition: all .2s;
   text-align: center;
+  text-decoration: underline;
 }
 
 .btn:hover {
@@ -177,6 +177,14 @@ a {
 
 .copyright a:hover {
   color: #5f5f5f;
+}
+
+.link-icon {
+  max-height: 8px;
+}
+
+.link-icon-large {
+  max-height: 12px;
 }
 
 @media(max-width: 1200px) {

--- a/styles/style.css
+++ b/styles/style.css
@@ -150,7 +150,7 @@ header h1 {
 
 .card-date {
   font-size: 12px;
-  margin-right: 25px;
+  margin-right: 12px;
   color: white;
 }
 
@@ -185,6 +185,29 @@ a {
 
 .link-icon-large {
   max-height: 12px;
+}
+
+.link-icon-white {
+  color: white;
+}
+
+.link-icon-card-container {
+  display: inline-block;
+  vertical-align: middle;
+  padding-bottom: 1px;
+}
+
+/* Visible only by screen reader */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media(max-width: 1200px) {


### PR DESCRIPTION
Added an icon next to links to visually indicate that the item moves into a new page. (Fixes #3)
It looks like that:
![Screenshot from 2025-01-14 22-40-03](https://github.com/user-attachments/assets/10baaa37-0460-43c9-bb38-258437d91771)
![Screenshot from 2025-01-14 22-39-53](https://github.com/user-attachments/assets/2360cc7a-4db2-4956-91bb-b397cb74cee1)

I've also used `aria-hidden="true"` so that the icon won't be read by a screen reader.
```
<span aria-hidden="true"><img src="assets/link_arrow.svg" class="link-icon-large"></span>
```

UPDATE from #12  
I've also added an icon in each card indicating that it opens the link to a new tab.
![Screenshot from 2025-02-25 03-52-57](https://github.com/user-attachments/assets/c4448fce-456a-4c8b-9450-ff33658e0502)

The icon is readable by screen readers. (`aria-hidden="true"`)
The card communicates that it will open the link in a new window. (`<span class="sr-only">Opens a new window</span>`)