### PR TITLE
Fix #11

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -56,24 +56,22 @@ function createCards(year,title,authors,publication,cat,link,desc) {
   var publication = (publication == "") ? "" : '<strong>Publication:</strong> ' + publication;
 
   var card =
-    `<div class="card" data-category-type="${cat}">
-        <a href="${link}" target="_blank">
-          <div class="card-header">
-            <span class="card-category">${cat}</span>
-            <span class="card-date">
-              ${year}
-              <span aria-hidden="true" class="link-icon-card-container"><img src="assets/link_arrow_white.svg" class="link-icon-large"></span>
-            </span>
-          </div>
-          <div class="card-content">
-            <h2 class="card-title">${title}</h2>
-            <p class="card-authors">${authors}</p>
-            <p class="card-publication">${publication}</p>
-            <p class="card-desc">${desc}</p>
-          </div>
-          <span class="sr-only">Opens a new window</span>
-        </a>
-      </div>`
+    `<a class="card" data-category-type="${cat}" href="${link}" target="_blank">
+        <div class="card-header">
+          <span class="card-category">${cat}</span>
+          <span class="card-date">
+            ${year}
+            <span aria-hidden="true" class="link-icon-card-container"><img src="assets/link_arrow_white.svg" class="link-icon-large"></span>
+          </span>
+        </div>
+        <div class="card-content">
+          <h2 class="card-title">${title}</h2>
+          <p class="card-authors">${authors}</p>
+          <p class="card-publication">${publication}</p>
+          <p class="card-desc">${desc}</p>
+        </div>
+        <span class="sr-only">Opens a new window</span>
+      </a>`
 
     $('.resources').append(card);
 };


### PR DESCRIPTION
This changes fixes #11 

Pressing `tab` focuses on a card:
![image](https://github.com/user-attachments/assets/0706753f-2fd2-40b9-adf3-1d0c35750dee)

Pressing `tab` a second time moves focus to the next card:
![image](https://github.com/user-attachments/assets/a7f7a08c-7278-4190-ad97-2f725db7a7cb)

I've tested the `tab` behavior in both Firefox and Chrome and I've tested the screen reader behavior on Linux (using Orca).
